### PR TITLE
Swapped config to have separate toggles for regular and fruit trees

### DIFF
--- a/src/AutoShaker/ModConfig.cs
+++ b/src/AutoShaker/ModConfig.cs
@@ -10,7 +10,8 @@ namespace AutoShaker
 	{
 		public bool IsShakerActive { get; set; }
 		public KeybindList ToggleShaker { get; set; }
-		public bool ShakeTrees { get; set; }
+		public bool ShakeRegularTrees { get; set; }
+		public bool ShakeFruitTrees { get; set; }
 		public bool ShakeBushes { get; set; }
 		public bool UsePlayerMagnetism { get; set; }
 		public int ShakeDistance { get; set; }
@@ -22,7 +23,8 @@ namespace AutoShaker
 				new Keybind(SButton.LeftAlt, SButton.H),
 				new Keybind(SButton.RightAlt, SButton.H));
 
-			ShakeTrees = true;
+			ShakeRegularTrees = true;
+			ShakeFruitTrees = true;
 			ShakeBushes = true;
 
 			UsePlayerMagnetism = false;
@@ -48,28 +50,38 @@ namespace AutoShaker
 				"Shaker Is Active",
 				"Whether or not the AutoShaker mod is active.",
 				() => IsShakerActive,
-				(val) => IsShakerActive = val);
+				val => IsShakerActive = val);
 
 			// ToggleShaker
-			//gmcmApi.RegisterSimpleOption(
-			//	manifest,
-			//	"Toggle Shaker Keybind",
-			//	"Keybinding to toggle the AutoShaker on and off.",
-			//	() => ToggleShaker,
-			//	(val) => ToggleShaker = val);
+			{
+				//gmcmApi.RegisterSimpleOption(
+				//	manifest,
+				//	"Toggle Shaker Keybind",
+				//	"Keybinding to toggle the AutoShaker on and off.",
+				//	() => ToggleShaker,
+				//	val => ToggleShaker = val);
 
-			gmcmApi.RegisterLabel(
-				manifest,
-				"ToggleShaker Keybind Currently Unavailable",
-				"Changing the ToggleShaker keybind is currently only possible via the config.json file directly due to recent changes. This should be temporary.");
+				gmcmApi.RegisterLabel(
+					manifest,
+					"ToggleShaker Keybind Currently Unavailable",
+					"Changing the ToggleShaker keybind is currently only possible via the config.json file directly due to recent changes. This should be temporary.");
+			}
 
-			// ShakeTrees
+			// ShakeRegularTrees
 			gmcmApi.RegisterSimpleOption(
 				manifest,
-				"Shake Trees?",
-				"Whether or not the AutoShaker will shake trees that you walk by.",
-				() => ShakeTrees,
-				(val) => ShakeTrees = val);
+				"Shake Regular Trees?",
+				"Whether or not the AutoShaker will shake regular trees that you walk by for seeds.",
+				() => ShakeRegularTrees,
+				val => ShakeRegularTrees = val);
+
+			// ShakeFruitTrees
+			gmcmApi.RegisterSimpleOption(
+				manifest,
+				"Shake Fruit Trees?",
+				"Whether or not the AutoShaker will shake fruit trees that you walk by for fruit.",
+				() => ShakeFruitTrees,
+				val => ShakeFruitTrees = val);
 
 			// ShakeBushes
 			gmcmApi.RegisterSimpleOption(
@@ -77,7 +89,7 @@ namespace AutoShaker
 				"Shake Bushes?",
 				"Whether or not the AutoShaker will shake bushes that you walk by.",
 				() => ShakeBushes,
-				(val) => ShakeBushes = val);
+				val => ShakeBushes = val);
 
 			// UsePlayerMagnetism
 			gmcmApi.RegisterSimpleOption(
@@ -85,7 +97,7 @@ namespace AutoShaker
 				"Use Player Magnetism Distance?",
 				"Whether or not the AutoShaker will shake bushes at the same distance players can pick up items. Note: Overrides 'Shake Distance'",
 				() => UsePlayerMagnetism,
-				(val) => UsePlayerMagnetism = val);
+				val => UsePlayerMagnetism = val);
 
 			// ShakeDistance
 			gmcmApi.RegisterSimpleOption(
@@ -93,7 +105,7 @@ namespace AutoShaker
 				"Shake Distance",
 				"Distance to shake bushes when not using 'Player Magnetism.'",
 				() => ShakeDistance,
-				(val) => ShakeDistance = val);
+				val => ShakeDistance = val);
 		}
 	}
 

--- a/src/AutoShaker/ModEntry.cs
+++ b/src/AutoShaker/ModEntry.cs
@@ -40,17 +40,16 @@ namespace AutoShaker
 		private void OnUpdateTicked(object sender, UpdateTickedEventArgs e)
 		{
 			if (!Game1.hasLoadedGame) return;
-			if (!_config.IsShakerActive) return;
+			if (!_config.IsShakerActive || (!_config.ShakeRegularTrees && !_config.ShakeFruitTrees && !_config.ShakeBushes)) return;
 			if (Game1.currentLocation == null || Game1.player == null) return;
 			if (Game1.CurrentEvent != null && (!Game1.CurrentEvent.playerControlSequence || !Game1.CurrentEvent.canPlayerUseTool())) return;
 			if (Game1.player.currentLocation.terrainFeatures.ToList().Count == 0 &&
 				Game1.player.currentLocation.largeTerrainFeatures.ToList().Count == 0) return;
 
-			
 			var playerTileLocationPoint = Game1.player.getTileLocationPoint();
 			var playerMagnetism = Game1.player.GetAppliedMagneticRadius();
 
-			if (_config.ShakeTrees)
+			if (_config.ShakeRegularTrees || _config.ShakeFruitTrees)
 			{
 				var trees = Game1.player.currentLocation.terrainFeatures.Pairs
 					.Select(p => p.Value)
@@ -65,6 +64,8 @@ namespace AutoShaker
 					switch (tree)
 					{
 						// Tree cases
+						case Tree _ when !_config.ShakeRegularTrees:
+							continue;
 						case Tree treeFeature when treeFeature.stump:
 							continue;
 						case Tree treeFeature when !treeFeature.hasSeed:
@@ -79,6 +80,8 @@ namespace AutoShaker
 							break;
 
 						// Fruit Tree cases
+						case FruitTree _ when !_config.ShakeFruitTrees:
+							continue;
 						case FruitTree fruitTree when fruitTree.stump:
 							continue;
 						case FruitTree fruitTree when fruitTree.fruitsOnTree.Value <= 0:
@@ -155,15 +158,18 @@ namespace AutoShaker
 
 		private void OnButtonsChanged(object sender, ButtonsChangedEventArgs e)
 		{
-			if (_config.ToggleShaker.JustPressed())
+			if (Game1.activeClickableMenu == null)
 			{
-				_config.IsShakerActive = !_config.IsShakerActive;
-				Helper.WriteConfig(_config);
+				if (_config.ToggleShaker.JustPressed())
+				{
+					_config.IsShakerActive = !_config.IsShakerActive;
+					Helper.WriteConfig(_config);
 
-				var message = "AutoShaker has been " + (_config.IsShakerActive ? "ACTIVATED" : "DEACTIVATED");
+					var message = "AutoShaker has been " + (_config.IsShakerActive ? "ACTIVATED" : "DEACTIVATED");
 
-				Monitor.Log(message, LogLevel.Info);
-				Game1.addHUDMessage(new HUDMessage(message, null));
+					Monitor.Log(message, LogLevel.Info);
+					Game1.addHUDMessage(new HUDMessage(message, null));
+				}
 			}
 		}
 

--- a/src/AutoShaker/manifest.json
+++ b/src/AutoShaker/manifest.json
@@ -1,8 +1,8 @@
 {
   "Name": "AutoShaker",
   "Author": "Jag3Dagster",
-  "Version": "1.1.0",
-  "Description": "Automatically shake bushes and trees as you walk by",
+  "Version": "1.2.0",
+  "Description": "Automatically shake bushes and trees as you walk by.",
   "UniqueID": "Jag3Dagster.AutoShaker",
   "EntryDll": "AutoShaker.dll",
   "MinimumApiVersion": "3.9.0",


### PR DESCRIPTION
- Added a check to ensure a user isn't in a menu when the button(s) for toggling the autoshaker are pressed
- Added some additional "early outs" when checking if a tree or bush should be shaken