### PR TITLE
Fixing a NullReferenceException thrown during split-screen instance

### DIFF
--- a/src/AutoShaker/manifest.json
+++ b/src/AutoShaker/manifest.json
@@ -1,7 +1,7 @@
 {
   "Name": "AutoShaker",
   "Author": "Jag3Dagster",
-  "Version": "1.3.1",
+  "Version": "1.3.2",
   "Description": "Automatically shake bushes and trees as you walk by.",
   "UniqueID": "Jag3Dagster.AutoShaker",
   "EntryDll": "AutoShaker.dll",


### PR DESCRIPTION
* Fixing a NullReferenceException thrown when a second user is joining a split-screen instance
* Updated the way the End-Of-Day messages are built
* Minor backend updates